### PR TITLE
fix: add telescope's `plenary.nvim` dependency

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -12,7 +12,7 @@ require("packer").startup(function(use)
   use({ "nvim-treesitter/nvim-treesitter", run = ":TSUpdate" }) -- Treesitter
   use("neovim/nvim-lspconfig") -- Configure LSP
   use("williamboman/nvim-lsp-installer") -- Install LSP servers (:LspInstall)
-  use("nvim-telescope/telescope.nvim") -- Pick files and more
+  use({ "nvim-telescope/telescope.nvim", requires = "nvim-lua/plenary.nvim" }) -- Pick files and more
   use({ "nvim-telescope/telescope-fzf-native.nvim", run = "make" })
   use("folke/which-key.nvim") -- Menu when pressing [space]
   use("lewis6991/impatient.nvim") -- Improve startup time by optimising Lua cache


### PR DESCRIPTION
[`telescope.nvim`](https://github.com/nvim-telescope/telescope.nvim#required-dependencies) requires [`plenary.nvim`](https://github.com/nvim-lua/plenary.nvim), but it wasn't in the list of packages so this error occurred when I tried installing `nvim-starter` in Docker:

![Telescope](https://user-images.githubusercontent.com/39676098/174220670-7bbbea24-09c3-46cf-900f-a52fa4985d66.png)

I added `plenary` as a dependency of `telescope` to solve this:

```lua
  use({ "nvim-telescope/telescope.nvim", requires = "nvim-lua/plenary.nvim" }) -- Pick files and more
```