### PR TITLE
feat: use global statusline option

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -39,6 +39,7 @@ vim.o.termguicolors = true -- full color in terminal
 vim.o.timeoutlen = 200
 vim.o.undofile = false -- no undo file
 vim.o.wrap = false -- no word wrap
+vim.o.laststatus = 3 -- global statusline
 vim.cmd([[color github_dark]])
 
 -- LSP installer


### PR DESCRIPTION
Use a global status line, which will make the status line fill up the entire horizontal space regardless of how many windows are open. We achieve this by simply setting `laststatus` to `3`.

Before:

![image](https://user-images.githubusercontent.com/39676098/174252290-0b61818a-a093-4be0-b2c4-db00e27c5968.png)

After:

![image](https://user-images.githubusercontent.com/39676098/174252318-6ee6512b-8a1a-417d-878c-aad24dc2685e.png)